### PR TITLE
propagate inputs into home manager.

### DIFF
--- a/modules/apps/home-manager.nix
+++ b/modules/apps/home-manager.nix
@@ -17,7 +17,7 @@
           useGlobalPkgs = true;
           useUserPackages = true;
           extraSpecialArgs = {
-            inherit host;
+            inherit host inputs;
           };
           users.${host.username} = {
             imports = host._internal.homeModules;

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -39,7 +39,7 @@ in {
   config.nixosConfigurations = mapAttrs
     (_: host: host._internal.pkgs.nixos {
       imports = host._internal.nixosModules ++ [
-        { _module.args.host = host; }
+        { _module.args = { inherit host inputs; }; }
       ];
     })
     nixosHosts


### PR DESCRIPTION
In order to use edge software, you sometimes have to take it directly from inputs, but that's not made available for home manager.