### PR TITLE
feat: enable apps with no explicit enable behavior and no tags

### DIFF
--- a/modules/lib/appType.nix
+++ b/modules/lib/appType.nix
@@ -36,6 +36,7 @@ in types.submodule {
       type = types.functionTo types.bool;
       default = { host, app, ... }:
         if (app.enable != null) then app.enable
+        else if (app.tags == [ ]) then true
         else (
           (builtins.any (tag: host.tags.${tag} or (throw "tag does not exist: '${tag}'")) app.tags)
           && !(builtins.any (tag: host.tags.${tag} or (throw "tag does not exist: '${tag}'")) app.disableTags)


### PR DESCRIPTION
* by default apps with no tags must be explicitly enabled
* this just swaps it to enabled by default otherwise